### PR TITLE
Add non-prefixed call example in dispatching RFC

### DIFF
--- a/features/rfc-oop-dispatching.rst
+++ b/features/rfc-oop-dispatching.rst
@@ -42,6 +42,8 @@ explicitly marked as static (for example, through 'Super). E.g:
 
    V.P; -- dispatching
 
+   P (V); -- also dispatching
+
 Default_Dispatching_Calls is On by default on new versions of the language.
 
 Note that the decision to dispatch or not is made at the point of the call, not


### PR DESCRIPTION
@QuentinOchem 

I'm pretty sure `Default_Dispatching_Calls` is supposed to apply to `Foo (X)` like it does to `X.Foo` so I propose to make it explicit in the RFC.